### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/TARAFramework/bdb668a0-32f7-4c0c-b6dd-cc579da31540/d78354ad-41e0-4fe2-a8b4-83174f98d34f/_apis/work/boardbadge/89de3ecf-efac-4cf0-8a54-a4ff1eacffd1)](https://dev.azure.com/TARAFramework/bdb668a0-32f7-4c0c-b6dd-cc579da31540/_boards/board/t/d78354ad-41e0-4fe2-a8b4-83174f98d34f/Microsoft.RequirementCategory)
 # go-tara
 
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/TARAFramework/bdb668a0-32f7-4c0c-b6dd-cc579da31540/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/taraframework/go-tara/32)
<!-- Reviewable:end -->
